### PR TITLE
Agent Label item 6, default should be jdk8

### DIFF
--- a/Exercise-01.md
+++ b/Exercise-01.md
@@ -87,7 +87,7 @@ OpenJDK 64-Bit Server VM (build 9.0.4+12-Debian-4, mixed mode)
 
 In addition to `any` and `label` you may also specify `none` and no global agent will be allocated for the entire Pipeline run and each `stage` section will need to contain its own `agent` section.
 
-6. Now change the value of the `label` to **default**
+6. Now change the value of the `label` to **jdk8**
 
 ```
    agent {


### PR DESCRIPTION
Item 6 said to change the lable to default but there is no agent
with that label.  The example shows to set it as jdk8, so this
update is to make the text match the example.